### PR TITLE
added option for X8M

### DIFF
--- a/oci-arch-ee-exa-db-mig/schema.yaml
+++ b/oci-arch-ee-exa-db-mig/schema.yaml
@@ -217,6 +217,7 @@ variables:
     title: "ExaCS Infrastructure Shape"
     description: "Choose the shape for your ExaCS Infrastructure."
     enum:
+      - "Exadata.X8M"
       - "Exadata.Quarter1.84"
       - "Exadata.Half1.168"
       - "Exadata.Full1.336"


### PR DESCRIPTION
Default options for Exadata shapes don't include X8M, which fails when existing options (such as Exadata.Quarter1.84) are selected with boolean X8 option selected, due to non-X8M shapes not allowing specification for exadata nodes. 

![image](https://user-images.githubusercontent.com/77116561/206764703-81da03a6-fcd2-48f7-998c-ed6203eb5709.png)

Added option to include "Exadata.X8M" so terraform apply doesn't fail when specifying exadata nodes.